### PR TITLE
Fix SQL table creation string

### DIFF
--- a/db.js
+++ b/db.js
@@ -35,10 +35,10 @@ db.serialize(() => {
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )`);
 
-  db.run(\`CREATE TABLE IF NOT EXISTS terms (
+  db.run(`CREATE TABLE IF NOT EXISTS terms (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     text TEXT
-  )\`);
+  )`);
 });
 
 module.exports = db;


### PR DESCRIPTION
## Summary
- correct quoting when creating `terms` table

## Testing
- `node --check db.js`
- `node --check app.js`
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68722c7ad17c832e90a9f09121bd76ae